### PR TITLE
Feat: Add AWS Secrets Manager & HashiCorp Vault Support 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           uv venv .venv --python 3.9
           source .venv/bin/activate
-          uv pip install ".[dev]"
+          uv pip install ".[dev,aws,vault]"
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -42,7 +42,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           uv venv .venv --python 3.10
           source .venv/bin/activate
-          uv pip install ".[dev]"
+          uv pip install ".[dev,aws,vault]"
       - name: Run tests
         run: |
           source .venv/bin/activate
@@ -61,7 +61,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           uv venv .venv --python 3.11
           source .venv/bin/activate
-          uv pip install ".[dev]"
+          uv pip install ".[dev,aws,vault]"
       - name: Run tests
         run: |
           source .venv/bin/activate

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -31,13 +31,7 @@ jobs:
         run: |
           uv venv .venv --python ${{ matrix.python-version }}
           source .venv/bin/activate
-          uv pip install ".[dev]"
-
-      # - name: Run linters (Ruff, Black)
-      #   run: |
-      #     source .venv/bin/activate # 각 run 스텝마다 필요할 수 있음
-      #     uv run ruff check .
-      #     uv run black . --check
+          uv pip install ".[dev,aws,vault]"
 
       - name: Run tests (pytest)
         run: |
@@ -52,24 +46,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.9"
 
       - name: Install UV
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
-      - name: Install build dependencies
-        run: uv pip install build hatchling
+      - name: Setup virtual environment and install build dependencies
+        run: |
+          uv venv .venv
+          source .venv/bin/activate
+          uv pip install build hatchling
 
       - name: Build package
-        run: python -m build
+        run: |
+          source .venv/bin/activate
+          python -m build
 
-      - name: publish package to PyPI
+      - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN}}
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -154,5 +154,4 @@ dmypy.json
 # Ruff cache
 .ruff_cache/
 
-
 volume

--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ dmypy.json
 
 # Ruff cache
 .ruff_cache/
+
+
+volume

--- a/README.md
+++ b/README.md
@@ -13,75 +13,178 @@ This tool is designed to help developers synchronize database schemas using Alem
 * **Configuration**: Uses Pydantic for clear and validated configuration of database connections, SSH tunnels, and masking rules.
 * **Chunking**: Processes data in chunks to manage memory usage effectively, especially for large tables.
 * **Flexible Table Selection**: Allows specifying tables to include or exclude from the dump/load process.
+* **External Secret Management**: Integration with AWS Secrets Manager and HashiCorp Vault for managing sensitive information.
 
 ## Installation
 
 You can install `alembic-dump` using `pip`:
 
 ```bash
+# Basic installation
 pip install alembic-dump
+
+# With AWS Secrets Manager support
+pip install alembic-dump[aws]
+
+# With HashiCorp Vault support
+pip install alembic-dump[vault]
+
+# With both secret management systems
+pip install alembic-dump[aws,vault]
+
+# For development (includes all optional dependencies)
+pip install alembic-dump[dev]
 ```
 
-baisc usage 
-```python3
-from alembic_dump.config import AppSettings, DBConfig, MaskingConfig, MaskingRule
+## Quick Start
+
+```python
 from alembic_dump.core import dump_and_load
+from alembic_dump.config import AppSettings
 
-# 1. Define Source and Target Database Configurations
-source_db_config = DBConfig(
-    driver="postgresql",
-    host="source.db.example.com",
-    port=5432,
-    username="user",
-    password="password", # In real use, manage secrets carefully (e.g., env vars)
-    database="sourcedb"
-)
-
-target_db_config = DBConfig(
-    driver="postgresql",
-    host="target.db.example.com",
-    port=5432,
-    username="user",
-    password="password",
-    database="targetdb"
-)
-
-# 2. (Optional) Define Masking Rules
-masking_config = MaskingConfig(
-    rules={
-        "users": {
-            "email": MaskingRule(strategy="hash"),
-            "full_name": MaskingRule(strategy="faker", faker_provider="name")
-        },
-        "sensitive_logs": {
-            "ip_address": MaskingRule(strategy="null")
-        }
+# Basic configuration
+settings = AppSettings(
+    source_db={
+        "driver": "postgresql",
+        "host": "source.example.com",
+        "port": 5432,
+        "username": "source_user",
+        "password": "source_pass",
+        "database": "source_db",
+    },
+    target_db={
+        "driver": "postgresql",
+        "host": "target.example.com",
+        "port": 5432,
+        "username": "target_user",
+        "password": "target_pass",
+        "database": "target_db",
     }
 )
 
-# 3. (Optional) Define SSH Tunnel Configuration if needed
-# ssh_config = SSHConfig(...)
-
-# 4. Create AppSettings
-app_settings = AppSettings(
-    source_db=source_db_config,
-    target_db=target_db_config,
-    # ssh_tunnel=ssh_config, # Uncomment if using SSH tunnel
-    masking=masking_config,
-    chunk_size=1000,
-    tables_to_exclude=["some_large_irrelevant_table"],
-    # tables_to_include=["users", "orders"] # Only include these if specified
-)
-
-# 5. Specify the path to your Alembic migrations directory
-# This directory should contain your alembic.ini and version scripts.
-alembic_migrations_directory = "/path/to/your/alembic_migrations" 
-# For testing, you might use a dedicated test Alembic environment.
-
-# 6. Run the dump and load process
-try:
-    dump_and_load(settings=app_settings, alembic_dir=alembic_migrations_directory)
-    print("Data dump and load completed successfully!")
-except Exception as e:
-    print(f"An error occurred: {e}")
+# Run the dump and load process
+dump_and_load(settings, alembic_dir="path/to/alembic")
 ```
+
+## Configuration
+
+Configuration can be provided through environment variables, a `.env` file, or directly in code using the `AppSettings` class.
+
+### Using Secret Management
+
+#### AWS Secrets Manager
+
+```python
+from alembic_dump.config import AppSettings
+
+settings = AppSettings(
+    source_db={
+        "driver": "postgresql",
+        "database": "source_db",
+        "secret_provider_config": {
+            "provider_type": "aws_secrets_manager",
+            "secret_id": "arn:aws:secretsmanager:region:account:secret:db-credentials",
+            "region_name": "us-west-2",
+            # Optional: role_arn for cross-account access
+            # "role_arn": "arn:aws:iam::account:role/role-name",
+            # Optional: profile_name for local AWS credentials
+            # "profile_name": "my-profile"
+        },
+        "secret_key_mapping": {
+            "host": "db_host",
+            "port": "db_port",
+            "username": "db_user",
+            "password": "db_pass"
+        }
+    }
+)
+```
+
+#### HashiCorp Vault
+
+```python
+from alembic_dump.config import AppSettings
+
+settings = AppSettings(
+    source_db={
+        "driver": "postgresql",
+        "database": "source_db",
+        "secret_provider_config": {
+            "provider_type": "hashicorp_vault",
+            "vault_addr": "https://vault.example.com:8200",
+            "secret_path": "secret/data/db-credentials",
+            # Either vault_token or role_id/secret_id must be provided
+            "vault_token": "s.token",
+            # "role_id": "role-id",
+            # "secret_id": "secret-id"
+        },
+        "secret_key_mapping": {
+            "host": "db_host",
+            "port": "db_port",
+            "username": "db_user",
+            "password": "db_pass"
+        }
+    }
+)
+```
+
+### Environment Variables
+
+All configuration can also be provided through environment variables:
+
+```bash
+# Basic configuration
+ALEMBIC_DUMP_SOURCE_DB__DRIVER=postgresql
+ALEMBIC_DUMP_SOURCE_DB__HOST=source.example.com
+ALEMBIC_DUMP_SOURCE_DB__PORT=5432
+ALEMBIC_DUMP_SOURCE_DB__USERNAME=source_user
+ALEMBIC_DUMP_SOURCE_DB__PASSWORD=source_pass
+ALEMBIC_DUMP_SOURCE_DB__DATABASE=source_db
+
+# AWS Secrets Manager configuration
+ALEMBIC_DUMP_SOURCE_DB__SECRET_PROVIDER_CONFIG__PROVIDER_TYPE=aws_secrets_manager
+ALEMBIC_DUMP_SOURCE_DB__SECRET_PROVIDER_CONFIG__SECRET_ID=arn:aws:secretsmanager:region:account:secret:db-credentials
+ALEMBIC_DUMP_SOURCE_DB__SECRET_PROVIDER_CONFIG__REGION_NAME=us-west-2
+ALEMBIC_DUMP_SOURCE_DB__SECRET_KEY_MAPPING__HOST=db_host
+ALEMBIC_DUMP_SOURCE_DB__SECRET_KEY_MAPPING__PORT=db_port
+ALEMBIC_DUMP_SOURCE_DB__SECRET_KEY_MAPPING__USERNAME=db_user
+ALEMBIC_DUMP_SOURCE_DB__SECRET_KEY_MAPPING__PASSWORD=db_pass
+
+# HashiCorp Vault configuration
+ALEMBIC_DUMP_SOURCE_DB__SECRET_PROVIDER_CONFIG__PROVIDER_TYPE=hashicorp_vault
+ALEMBIC_DUMP_SOURCE_DB__SECRET_PROVIDER_CONFIG__VAULT_ADDR=https://vault.example.com:8200
+ALEMBIC_DUMP_SOURCE_DB__SECRET_PROVIDER_CONFIG__SECRET_PATH=secret/data/db-credentials
+ALEMBIC_DUMP_SOURCE_DB__SECRET_PROVIDER_CONFIG__VAULT_TOKEN=s.token
+```
+
+## Development
+
+1. Clone the repository:
+   ```bash
+   git clone https://github.com/jaeyoung0509/alembic-dump.git
+   cd alembic-dump
+   ```
+
+2. Create and activate a virtual environment:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   ```
+
+3. Install development dependencies:
+   ```bash
+   pip install -e ".[dev]"
+   ```
+
+4. Run tests:
+   ```bash
+   pytest
+   ```
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
+
+## License
+
+MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ keywords = [
 license = {file = "LICENSE"}
 
 [project.optional-dependencies]
+aws = [
+  "boto3>=1.28.0",
+  "boto3-stubs[secretsmanager]>=1.28.0",
+]
 dev = [
   "black",
   "ruff",
@@ -68,6 +72,9 @@ dev = [
   "sphinx-rtd-theme",
   "build",
   "twine>=4.0.0",
+]
+vault = [
+  "hvac>=1.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "A Python library to dump, load, and mask data between databases i
 name = "alembic-dump"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.1.6"
+version = "0.1.7"
 
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/src/alembic_dump/config.py
+++ b/src/alembic_dump/config.py
@@ -1,13 +1,15 @@
-from typing import Any, Optional, TypedDict, Union
+from typing import Any, Optional, Union
 
 from pydantic import BaseModel, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from typing_extensions import TypedDict
 
 from .secrets import AWSSecretsManagerConfig, HashiCorpVaultConfig
 
 
 class SecretKeyMapping(TypedDict, total=False):
     """Mapping of DBConfig fields to secret keys"""
+
     username: str
     password: str
     host: str
@@ -49,11 +51,13 @@ class DBConfig(BaseModel):
     options: dict[str, Any] = Field(default_factory=dict)
 
     # Secret provider configuration
-    secret_provider_config: Optional[Union[AWSSecretsManagerConfig, HashiCorpVaultConfig]] = None
+    secret_provider_config: Optional[
+        Union[AWSSecretsManagerConfig, HashiCorpVaultConfig]
+    ] = None
     # Mapping of DBConfig fields to secret keys
     secret_key_mapping: Optional[SecretKeyMapping] = Field(
         None,
-        description="Mapping of DBConfig fields to secret keys (e.g., {'username': 'db_user', 'password': 'db_pass'})"
+        description="Mapping of DBConfig fields to secret keys (e.g., {'username': 'db_user', 'password': 'db_pass'})",
     )
 
     def __init__(self, **data: Any) -> None:
@@ -64,8 +68,9 @@ class DBConfig(BaseModel):
         """Populate fields from secret provider if configured"""
         if self.secret_provider_config and self.secret_key_mapping:
             from .secrets import create_secret_provider
+
             provider = create_secret_provider(self.secret_provider_config)
-            
+
             for field, secret_key in self.secret_key_mapping.items():
                 if not isinstance(secret_key, str):
                     continue
@@ -95,15 +100,15 @@ class DBConfig(BaseModel):
                     "secret_provider_config": {
                         "provider_type": "aws_secrets_manager",
                         "secret_id": "arn:aws:secretsmanager:region:account:secret:db-credentials",
-                        "region_name": "us-west-2"
+                        "region_name": "us-west-2",
                     },
                     "secret_key_mapping": {
                         "host": "db_host",
                         "port": "db_port",
                         "username": "db_user",
-                        "password": "db_pass"
-                    }
-                }
+                        "password": "db_pass",
+                    },
+                },
             ]
         }
     }

--- a/src/alembic_dump/config.py
+++ b/src/alembic_dump/config.py
@@ -1,7 +1,18 @@
-from typing import Any, Optional
+from typing import Any, Optional, TypedDict, Union
 
 from pydantic import BaseModel, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .secrets import AWSSecretsManagerConfig, HashiCorpVaultConfig
+
+
+class SecretKeyMapping(TypedDict, total=False):
+    """Mapping of DBConfig fields to secret keys"""
+    username: str
+    password: str
+    host: str
+    port: str
+    database: str
 
 
 class SSHConfig(BaseModel):
@@ -30,12 +41,42 @@ class DBConfig(BaseModel):
         description="Database driver (e.g., postgresql)",
         examples=["postgresql"],
     )
-    host: str
+    host: Optional[str] = None
     port: Optional[int] = None
-    username: str
-    password: SecretStr
-    database: str
+    username: Optional[str] = None
+    password: Optional[SecretStr] = None
+    database: Optional[str] = None
     options: dict[str, Any] = Field(default_factory=dict)
+
+    # Secret provider configuration
+    secret_provider_config: Optional[Union[AWSSecretsManagerConfig, HashiCorpVaultConfig]] = None
+    # Mapping of DBConfig fields to secret keys
+    secret_key_mapping: Optional[SecretKeyMapping] = Field(
+        None,
+        description="Mapping of DBConfig fields to secret keys (e.g., {'username': 'db_user', 'password': 'db_pass'})"
+    )
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+        self._populate_from_secret_provider()
+
+    def _populate_from_secret_provider(self) -> None:
+        """Populate fields from secret provider if configured"""
+        if self.secret_provider_config and self.secret_key_mapping:
+            from .secrets import create_secret_provider
+            provider = create_secret_provider(self.secret_provider_config)
+            
+            for field, secret_key in self.secret_key_mapping.items():
+                if not isinstance(secret_key, str):
+                    continue
+                value = provider.get_secret_value(secret_key)
+                if value is not None:
+                    if field == "password":
+                        setattr(self, field, SecretStr(value))
+                    elif field == "port":
+                        setattr(self, field, int(value))
+                    else:
+                        setattr(self, field, value)
 
     model_config = {
         "json_schema_extra": {
@@ -47,6 +88,21 @@ class DBConfig(BaseModel):
                     "username": "db_user",
                     "password": "secret",
                     "database": "my_db",
+                },
+                {
+                    "driver": "postgresql",
+                    "database": "my_db",
+                    "secret_provider_config": {
+                        "provider_type": "aws_secrets_manager",
+                        "secret_id": "arn:aws:secretsmanager:region:account:secret:db-credentials",
+                        "region_name": "us-west-2"
+                    },
+                    "secret_key_mapping": {
+                        "host": "db_host",
+                        "port": "db_port",
+                        "username": "db_user",
+                        "password": "db_pass"
+                    }
                 }
             ]
         }

--- a/src/alembic_dump/secrets.py
+++ b/src/alembic_dump/secrets.py
@@ -1,0 +1,223 @@
+import logging
+from typing import Optional, Protocol, Union
+
+import boto3
+import hvac
+from botocore.config import Config
+from mypy_boto3_secretsmanager import SecretsManagerClient
+from pydantic import BaseModel, Field, SecretStr
+
+logger = logging.getLogger(__name__)
+
+
+# --- Base Secret Provider Protocol ---
+class SecretProvider(Protocol):
+    """Protocol defining the interface for secret providers"""
+
+    def get_secret_value(self, key_name: str) -> Optional[str]:
+        """Get a specific secret value by key name"""
+        ...
+
+    def get_all_secrets(self) -> dict[str, Optional[str]]:
+        """Get all secrets as a dictionary"""
+        ...
+
+
+# --- AWS Secrets Manager ---
+class AWSSecretsManagerConfig(BaseModel):
+    """Configuration for AWS Secrets Manager"""
+
+    provider_type: str = "aws_secrets_manager"
+    secret_id: str = Field(description="The ARN or name of the secret")
+    region_name: Optional[str] = Field(None, description="AWS region name")
+    role_arn: Optional[str] = Field(None, description="IAM role ARN to assume")
+    profile_name: Optional[str] = Field(None, description="AWS profile name")
+    endpoint_url: Optional[str] = Field(
+        None, description="Custom endpoint URL for localstack or other services"
+    )
+
+
+class AWSSecretsManagerProvider:
+    """AWS Secrets Manager implementation"""
+
+    def __init__(self, config: AWSSecretsManagerConfig) -> None:
+        """Initialize the AWS Secrets Manager provider with the given configuration"""
+        self.config = config
+        self._client = None
+
+    def _get_client(self) -> SecretsManagerClient:
+        """Lazy initialization of boto3 client
+
+        Returns:
+            Initialized boto3 Secrets Manager client
+
+        Raises:
+            RuntimeError: If client initialization fails
+        """
+        if self._client is None:
+            try:
+                # If endpoint_url is provided, use test credentials for LocalStack
+                if self.config.endpoint_url:
+                    session = boto3.Session(
+                        aws_access_key_id="test",
+                        aws_secret_access_key="test",
+                        region_name=self.config.region_name,
+                    )
+                    self._client = session.client(
+                        "secretsmanager",
+                        endpoint_url=self.config.endpoint_url,
+                        region_name=self.config.region_name,
+                        config=Config(
+                            signature_version="s3v4",
+                            retries={"max_attempts": 0},
+                        ),
+                    )
+                else:
+                    # Use normal AWS credentials for production
+                    session = boto3.Session(
+                        region_name=self.config.region_name,
+                        profile_name=self.config.profile_name,
+                    )
+
+                    if self.config.role_arn:
+                        logger.debug(f"Assuming role: {self.config.role_arn}")
+                        sts = session.client("sts")
+                        assumed_role = sts.assume_role(
+                            RoleArn=self.config.role_arn,
+                            RoleSessionName="AlembicDumpSecretAccess",
+                        )
+                        credentials = assumed_role["Credentials"]
+                        session = boto3.Session(
+                            aws_access_key_id=credentials["AccessKeyId"],
+                            aws_secret_access_key=credentials["SecretAccessKey"],
+                            aws_session_token=credentials["SessionToken"],
+                            region_name=self.config.region_name,
+                        )
+
+                    self._client = session.client("secretsmanager")
+
+                logger.debug("Successfully initialized AWS Secrets Manager client")
+            except Exception as e:
+                logger.error(f"Failed to initialize AWS Secrets Manager client: {e}")
+                raise RuntimeError(
+                    f"Failed to initialize AWS Secrets Manager client: {e}"
+                ) from e
+        return self._client
+
+    def get_secret_value(self, key_name: str) -> Optional[str]:
+        """Get a specific secret value by key name"""
+        try:
+            response = self._get_client().get_secret_value(
+                SecretId=self.config.secret_id
+            )
+            secret_string = response["SecretString"]
+            import json
+
+            try:
+                # Try to parse as JSON
+                secret_dict = json.loads(secret_string)
+                return secret_dict.get(key_name)
+            except json.JSONDecodeError:
+                # If not JSON, return the whole string if key_name matches a convention
+                if key_name == "password":
+                    return secret_string
+                return None
+        except Exception as e:
+            raise RuntimeError(f"Failed to get secret value: {e}") from e
+
+    def get_all_secrets(self) -> dict[str, Optional[str]]:
+        """Get all secrets as a dictionary"""
+        try:
+            response = self._get_client().get_secret_value(
+                SecretId=self.config.secret_id
+            )
+            secret_string = response["SecretString"]
+            import json
+
+            try:
+                # Try to parse as JSON
+                return json.loads(secret_string)
+            except json.JSONDecodeError:
+                # If not JSON, return as single password
+                return {"password": secret_string}
+        except Exception as e:
+            raise RuntimeError(f"Failed to get all secrets: {e}") from e
+
+
+# --- HashiCorp Vault ---
+class HashiCorpVaultConfig(BaseModel):
+    """Configuration for HashiCorp Vault"""
+
+    provider_type: str = "hashicorp_vault"
+    vault_addr: str = Field(description="Vault server address")
+    secret_path: str = Field(description="Path to the secret in Vault")
+    vault_token: Optional[SecretStr] = Field(
+        None, description="Vault token for authentication"
+    )
+    role_id: Optional[str] = Field(None, description="AppRole role ID")
+    secret_id: Optional[SecretStr] = Field(None, description="AppRole secret ID")
+
+
+class HashiCorpVaultProvider:
+    """HashiCorp Vault implementation"""
+
+    def __init__(self, config: HashiCorpVaultConfig) -> None:
+        self.config = config
+        self._client = None
+
+    def _get_client(self) -> hvac.Client:
+        """Lazy initialization of hvac client"""
+        if self._client is None:
+            client = hvac.Client(url=self.config.vault_addr)
+
+            if self.config.vault_token:
+                client.token = self.config.vault_token.get_secret_value()
+            elif self.config.role_id and self.config.secret_id:
+                client.auth.approle.login(
+                    role_id=self.config.role_id,
+                    secret_id=self.config.secret_id.get_secret_value(),
+                )
+            else:
+                raise ValueError(
+                    "Either vault_token or role_id/secret_id must be provided"
+                )
+
+            self._client = client
+        return self._client
+
+    def get_secret_value(self, key_name: str) -> Optional[str]:
+        """Get a specific secret value by key name"""
+        try:
+            response = self._get_client().secrets.kv.v2.read_secret_version(
+                path=self.config.secret_path
+            )
+            if response and "data" in response and "data" in response["data"]:
+                return response["data"]["data"].get(key_name)
+            return None
+        except Exception as e:
+            raise RuntimeError(f"Failed to get secret value: {e}") from e
+
+    def get_all_secrets(self) -> dict[str, Optional[str]]:
+        """Get all secrets as a dictionary"""
+        try:
+            response = self._get_client().secrets.kv.v2.read_secret_version(
+                path=self.config.secret_path
+            )
+            if response and "data" in response and "data" in response["data"]:
+                return response["data"]["data"]
+            return {}
+        except Exception as e:
+            raise RuntimeError(f"Failed to get all secrets: {e}") from e
+
+
+# --- Factory function ---
+def create_secret_provider(
+    config: Union[AWSSecretsManagerConfig, HashiCorpVaultConfig],
+) -> SecretProvider:
+    """Factory function to create appropriate secret provider"""
+    if isinstance(config, AWSSecretsManagerConfig):
+        return AWSSecretsManagerProvider(config)
+    elif isinstance(config, HashiCorpVaultConfig):
+        return HashiCorpVaultProvider(config)
+    else:
+        raise ValueError(f"Unsupported secret provider config type: {type(config)}")

--- a/src/alembic_dump/ssh.py
+++ b/src/alembic_dump/ssh.py
@@ -45,10 +45,12 @@ class SSHTunnelManager:
             ssh_host_key=None,
         )
 
+        if self._tunnel is None:
+            raise ValueError("tunnel can not be None")
         self._tunnel.start()
 
     def stop(self) -> None:
-        if self._tunnel is not None:
+        if self._tunnel is not None and self._tunnel.is_active:
             self._tunnel.stop()
             self._tunnel = None
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,242 @@
+import json
+from contextlib import suppress
+from typing import Any
+
+import boto3
+import hvac
+import pytest
+from mypy_boto3_secretsmanager import SecretsManagerClient
+from pydantic import SecretStr
+
+from alembic_dump.config import AppSettings, DBConfig
+from alembic_dump.secrets import (
+    AWSSecretsManagerConfig,
+    HashiCorpVaultConfig,
+    create_secret_provider,
+)
+
+
+@pytest.fixture
+def aws_secrets_manager_config(
+    localstack_container: dict[str, Any],
+) -> AWSSecretsManagerConfig:
+    """Create AWS Secrets Manager configuration for testing"""
+    return AWSSecretsManagerConfig(
+        provider_type="aws_secrets_manager",
+        secret_id="test-secret",
+        endpoint_url=localstack_container["endpoint_url"],
+        region_name="us-east-1",
+        role_arn=None,
+        profile_name=None,
+    )
+
+
+@pytest.fixture
+def hashicorp_vault_config(vault_container: dict[str, Any]) -> HashiCorpVaultConfig:
+    """Create HashiCorp Vault configuration for testing"""
+    return HashiCorpVaultConfig(
+        provider_type="hashicorp_vault",
+        vault_addr=vault_container["url"],
+        secret_path="db-credentials",
+        vault_token=SecretStr(vault_container["token"]),
+        role_id=None,
+        secret_id=None,
+    )
+
+
+@pytest.fixture
+def aws_secrets_manager_client(
+    localstack_container: dict[str, Any],
+) -> SecretsManagerClient:
+    """Create AWS Secrets Manager client for testing"""
+    session = boto3.session.Session()
+    return session.client(
+        "secretsmanager",
+        endpoint_url=localstack_container["endpoint_url"],
+        region_name="us-east-1",
+        aws_access_key_id="test",
+        aws_secret_access_key="test",
+    )
+
+
+@pytest.fixture
+def vault_client(vault_container: dict[str, Any]) -> hvac.Client:
+    """Create HashiCorp Vault client for testing"""
+    client = hvac.Client(url=vault_container["url"], token=vault_container["token"])
+    return client
+
+
+def test_aws_secrets_manager_provider(
+    aws_secrets_manager_config: AWSSecretsManagerConfig,
+    aws_secrets_manager_client: SecretsManagerClient,
+) -> None:
+    """Test AWS Secrets Manager provider"""
+    with suppress(aws_secrets_manager_client.exceptions.ResourceNotFoundException):
+        # Clean up secret if it exists
+        aws_secrets_manager_client.delete_secret(
+            SecretId=aws_secrets_manager_config.secret_id,
+            ForceDeleteWithoutRecovery=True,
+        )
+
+    # Create test secret
+    test_secret = {
+        "username": "test_user",
+        "password": "test_password",
+        "host": "test_host",
+        "port": "5432",
+    }
+    aws_secrets_manager_client.create_secret(
+        Name=aws_secrets_manager_config.secret_id,
+        SecretString=json.dumps(test_secret),
+    )
+
+    # Create provider and test
+    provider = create_secret_provider(aws_secrets_manager_config)
+    assert provider.get_secret_value("username") == "test_user"
+
+
+def test_hashicorp_vault_provider(
+    hashicorp_vault_config: HashiCorpVaultConfig,
+    vault_client: hvac.Client,
+) -> None:
+    """Test HashiCorp Vault provider"""
+    # Clean up secret if it exists
+    with suppress(vault_client.secrets.kv.v2.delete_metadata_and_all_versions):
+        vault_client.secrets.kv.v2.delete_metadata_and_all_versions(
+            path=hashicorp_vault_config.secret_path
+        )
+
+    # Create test secret
+    test_secret = {
+        "username": "test_user",
+        "password": "test_password",
+        "host": "test_host",
+        "port": "5432",
+    }
+    vault_client.secrets.kv.v2.create_or_update_secret(
+        path=hashicorp_vault_config.secret_path,
+        secret=test_secret,
+    )
+
+    # Create provider and test
+    provider = create_secret_provider(hashicorp_vault_config)
+    assert provider.get_secret_value("username") == "test_user"
+    assert provider.get_secret_value("password") == "test_password"
+
+
+def test_db_config_with_aws_secrets(
+    aws_secrets_manager_config: AWSSecretsManagerConfig,
+    aws_secrets_manager_client: SecretsManagerClient,
+) -> None:
+    """Test DBConfig with AWS Secrets Manager"""
+    # Clean up secret if it exists
+    with suppress(aws_secrets_manager_client.exceptions.ResourceNotFoundException):
+        aws_secrets_manager_client.delete_secret(
+            SecretId=aws_secrets_manager_config.secret_id,
+            ForceDeleteWithoutRecovery=True,
+        )
+
+    # Create test secret
+    test_secret = {
+        "db_user": "test_user",
+        "db_pass": "test_password",
+        "db_host": "test_host",
+        "db_port": "5432",
+    }
+    aws_secrets_manager_client.create_secret(
+        Name=aws_secrets_manager_config.secret_id,
+        SecretString=json.dumps(test_secret),
+    )
+
+
+def test_db_config_with_vault_secrets(
+    hashicorp_vault_config: HashiCorpVaultConfig,
+    vault_client: hvac.Client,
+) -> None:
+    """Test DBConfig with HashiCorp Vault"""
+    # Clean up secret if it exists
+    with suppress(vault_client.secrets.kv.v2.delete_metadata_and_all_versions):
+        vault_client.secrets.kv.v2.delete_metadata_and_all_versions(
+            path=hashicorp_vault_config.secret_path
+        )
+
+    # Create test secret
+    test_secret = {
+        "db_user": "test_user",
+        "db_pass": "test_password",
+        "db_host": "test_host",
+        "db_port": "5432",
+    }
+    vault_client.secrets.kv.v2.create_or_update_secret(
+        path=hashicorp_vault_config.secret_path,
+        secret=test_secret,
+    )
+
+    # Test configuration values
+    provider = create_secret_provider(hashicorp_vault_config)
+    assert provider.get_secret_value("db_user") == "test_user"
+    assert provider.get_secret_value("db_pass") == "test_password"
+    assert provider.get_secret_value("db_host") == "test_host"
+    assert provider.get_secret_value("db_port") == "5432"
+
+
+def test_app_settings_with_secrets(
+    aws_secrets_manager_config: AWSSecretsManagerConfig,
+    aws_secrets_manager_client: SecretsManagerClient,
+) -> None:
+    """Test AppSettings with secret providers"""
+    # Clean up existing secret if it exists
+    with suppress(aws_secrets_manager_client.exceptions.ResourceNotFoundException):
+        aws_secrets_manager_client.delete_secret(
+            SecretId=aws_secrets_manager_config.secret_id,
+            ForceDeleteWithoutRecovery=True,
+        )
+
+    # Create test secret
+    test_secret = {
+        "db_user": "test_user",
+        "db_pass": "test_password",
+        "db_host": "test_host",
+        "db_port": "5432",
+    }
+    aws_secrets_manager_client.create_secret(
+        Name=aws_secrets_manager_config.secret_id,
+        SecretString=json.dumps(test_secret),
+    )
+
+    # Create AppSettings with secret provider
+    settings = AppSettings(
+        source_db=DBConfig(
+            driver="postgresql",
+            database="test_db",
+            secret_provider_config=aws_secrets_manager_config,
+            secret_key_mapping={
+                "username": "db_user",
+                "password": "db_pass",
+                "host": "db_host",
+                "port": "db_port",
+            },
+            password=SecretStr("test_password"),
+        ),
+        target_db=DBConfig(
+            driver="postgresql",
+            host="target.example.com",
+            port=5432,
+            username="target_user",
+            password=SecretStr("target_pass"),
+            database="target_db",
+            secret_key_mapping=None,
+        ),
+    )
+
+    # Test source database configuration
+    assert settings.source_db.username == "test_user"
+    assert settings.source_db.password.get_secret_value() == "test_password" #type: ignore
+    assert settings.source_db.host == "test_host"
+    assert settings.source_db.port == 5432
+
+    # Test target database configuration (direct values)
+    assert settings.target_db.username == "target_user"
+    assert settings.target_db.password.get_secret_value() == "target_pass" #type: ignore
+    assert settings.target_db.host == "target.example.com"
+    assert settings.target_db.port == 5432


### PR DESCRIPTION
#### Related Issues: #12 
#### Key Changes:

#### New Secret Providers:
Implemented AWSSecretsManagerProvider to retrieve secrets from AWS Secrets Manager. Supports IAM role assumption and custom endpoint URLs (e.g., for LocalStack).
Implemented HashiCorpVaultProvider to retrieve secrets from HashiCorp Vault KV v2. Supports token and AppRole authentication.
#### Configuration Update:
DBConfig now accepts secret_provider_config (for either AWS or Vault) and secret_key_mapping to dynamically populate connection parameters (username, password, host, port, database) from the chosen secret manager.
#### Vault Path Correction:
Fixed an InvalidPath error in the HashiCorpVaultProvider by ensuring secret_path in HashiCorpVaultConfig refers to the pure secret path (e.g., db-credentials) excluding the KV v2 engine's mount point (secret/) and the API's data/ segment.
Removed unnecessary secret_path manipulation in test_hashicorp_vault_provider to align with the corrected secret_path definition.
#### Testing:
Added new tests for AWSSecretsManagerProvider and HashiCorpVaultProvider.
Updated existing tests to cover DBConfig and AppSettings integration with the new secret providers.